### PR TITLE
Added support for Jupyter-lab

### DIFF
--- a/myhdlpeek/myhdlpeek.py
+++ b/myhdlpeek/myhdlpeek.py
@@ -51,6 +51,7 @@ from tabulate import tabulate
 
 import IPython.display as DISP
 import json
+import nbwavedrom
 
 logger = logging.getLogger('myhdlpeek')
 
@@ -755,6 +756,37 @@ class Peeker(object):
         skin = kwargs.get('skin', 'default')
 
         wavejson_to_wavedrom(cls.to_wavejson(*names, **kwargs), width=width, skin=skin)
+        
+    @classmethod
+    def to_nbwavedrom(cls, *names, **kwargs):
+        '''
+        Display waveforms stored in peekers in Jupyter notebook.
+
+        Args:
+            *names: A list of strings containing the names for the Peekers that
+                will be displayed. A string may contain multiple,
+                space-separated names.
+
+        Keywords Args:
+            start_time: The earliest (left-most) time bound for the waveform display.
+            stop_time: The latest (right-most) time bound for the waveform display.
+            title: String containing the title placed across the top of the display.
+            caption: String containing the title placed across the bottom of the display.
+            tick: If true, times are shown at the tick marks of the display.
+            tock: If true, times are shown between the tick marks of the display.
+            width: The width of the waveform display in pixels.
+            skin: Selects the set of graphic elements used to create waveforms.
+
+        Returns:
+            Nothing.
+        '''
+
+        # Handle keyword args explicitly for Python 2 compatibility.
+        width = kwargs.get('width')
+        skin = kwargs.get('skin', 'default')
+
+        #wavejson_to_wavedrom(cls.to_wavejson(*names, **kwargs), width=width, skin=skin)
+        return nbwavedrom.draw(cls.to_wavejson(*names, **kwargs))
 
     @classmethod
     def to_dataframe(cls, *names, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ requirements = [
     'myhdl',
     'tabulate',
     'pandas',
+    'nbwavedrom'
 ]
 
 test_requirements = [


### PR DESCRIPTION
'nbwavedrom' support have come to jupyter-lab. With this change one can see wave forms in jupyter-lab by utilising nbwavedrom.

```python
from myhdl import *
from myhdlpeek import Peeker  # Import the myhdlpeeker module.

def mux(z, a, b, sel):
    """A simple multiplexer."""

    @always_comb
    def mux_logic():
        if sel == 1:
            z.next = a  # Signal a sent to mux output when sel is high.
        else:
            z.next = b  # Signal b sent to mux output when sel is low.
           
    return mux_logic

# Create some signals to attach to the multiplexer.
a, b, z = [Signal(0) for _ in range(3)]  # Integer signals for the inputs & output.
sel = Signal(bool(0))                    # Binary signal for the selector.

# Create some Peekers to monitor the multiplexer I/Os.
Peeker.clear()         # Clear any existing Peekers. (Start with a clean slate.)
Peeker(a, 'a')         # Add a Peeker to the a input.
Peeker(b, 'b')         # Add a Peeker to the b input.
Peeker(z, 'z')         # Add a peeker to the z output.
Peeker(sel, 'select')  # Add a Peeker to the select input. The Peeker label doesn't have to match the signal name.

# Instantiate mux.
mux_1 = mux(z, a, b, sel)

# Create a simple testbed to apply random patterns to the multiplexer.
from random import randrange
def test():
    '''Simple testbed generator that applies random inputs to the multiplexer.'''
    print("t  z a b sel")
    for _ in range(18):
        a.next, b.next, sel.next = randrange(8), randrange(8), randrange(2)
        yield delay(1)
        #print("%d  %s %s %s %s" % (now(), z, a, b, sel))

# Simulate the multiplexer, testbed and the peekers.
sim = Simulation(mux_1, test(), *Peeker.instances()).run()

# Display the complete waveforms captured by all the Peekers. 
Peeker.to_nbwavedrom()
```